### PR TITLE
set print.class=FALSE before test

### DIFF
--- a/inst/tinytest/test_createQTLmpp.R
+++ b/inst/tinytest/test_createQTLmpp.R
@@ -24,6 +24,7 @@ ABC <- calcIBDMPP(crossNames = c("AxB", "AxC"),
 ABC_MQM <- selQTLMPP(MPPobj = ABC, trait = "yield")
 
 ## Summary.
+options(datatable.print.class=FALSE)
 sumABC <- capture.output(summary(ABC_MQM))
 expect_true("Number of QTLs: 3 " %in% sumABC)
 expect_true("Threshold: 3 " %in% sumABC)


### PR DESCRIPTION
hi @BartJanvanRossum 
When `data.table` from github master is installed, `data.table::update_dev_pkg()`
statgenMPP has new test failures, https://github.com/Rdatatable/data.table/issues/5535 because the new default is `options(datatable.print.class=TRUE)` whereas it was previously FALSE.
This PR provides a fix for your test, by setting the option to the old default before running the test.
You may also consider simply removing this test (it is not good practice to test the printed output), or grep for specific substrings you are looking for in the output, instead of testing equality of entire lines.